### PR TITLE
Rollback PSR installation causing massive workflow failures

### DIFF
--- a/scripts/install-php-packages.sh
+++ b/scripts/install-php-packages.sh
@@ -116,10 +116,6 @@ if [[ $PHP_VERSION != "5.6" ]]; then
   DEBIAN_FRONTEND=noninteractive apt-fast install -y --no-install-recommends php$PHP_VERSION-ds
 fi
 
-if [[ $PHP_VERSION != "5.6" ]]; then
-  DEBIAN_FRONTEND=noninteractive apt-fast install -y --no-install-recommends php$PHP_VERSION-psr || true
-fi
-
 if [[ $PHP_VERSION = "7.0" || $PHP_VERSION = "7.1" ]]; then
   DEBIAN_FRONTEND=noninteractive apt-fast install -y --no-install-recommends php$PHP_VERSION-sodium
   [ "${BUILDS:?}" = "debug" ] && apt-fast install -y --no-install-recommends php$PHP_VERSION-sodium$PHP_PKG_SUFFIX


### PR DESCRIPTION
This reverts commit 83d1155cd11a0178b4d7431a0c91ed6c1b7454ad "Revert 'Add psr for PHP 7.0 and above'" as it breaks installations. This rollback will fix https://github.com/shivammathur/setup-php/issues/798 and https://github.com/shivammathur/setup-php/issues/799